### PR TITLE
Update version (potential security issue fixed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurkar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ava macros to test RxJS, with TypeScript support",
   "main": "dist/marbles.js",
   "types": "dist/marbles.d.ts",


### PR DESCRIPTION
This is used in Ava dependency `concordance`.  So runs only in tests.  Easiest just to fix it.